### PR TITLE
Add social client search example

### DIFF
--- a/social-client-search/.env.example
+++ b/social-client-search/.env.example
@@ -1,3 +1,4 @@
 FACEBOOK_ACCESS_TOKEN=your_facebook_token
+INSTAGRAM_ACCESS_TOKEN=your_instagram_token
 TWITTER_BEARER_TOKEN=your_twitter_token
 PORT=3000

--- a/social-client-search/.env.example
+++ b/social-client-search/.env.example
@@ -1,0 +1,3 @@
+FACEBOOK_ACCESS_TOKEN=your_facebook_token
+TWITTER_BEARER_TOKEN=your_twitter_token
+PORT=3000

--- a/social-client-search/.eslintrc.json
+++ b/social-client-search/.eslintrc.json
@@ -1,4 +1,10 @@
 {
-  "env": { "node": true, "es2020": true },
-  "extends": "eslint:recommended"
+  "env": {
+    "node": true,
+    "es2020": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "sourceType": "module"
+  }
 }

--- a/social-client-search/.eslintrc.json
+++ b/social-client-search/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "env": { "node": true, "es2020": true },
+  "extends": "eslint:recommended"
+}

--- a/social-client-search/README.md
+++ b/social-client-search/README.md
@@ -1,0 +1,11 @@
+# Social Client Search
+
+This example demonstrates a simple Node.js script that searches for potential clients on Facebook and Instagram using Meta's Graph API. You must provide your own access token with the necessary permissions.
+
+**Usage:**
+
+```bash
+FACEBOOK_ACCESS_TOKEN=<token> node client-search.js "search query"
+```
+
+The script prints basic information about matching Facebook pages and Instagram hashtags.

--- a/social-client-search/README.md
+++ b/social-client-search/README.md
@@ -1,11 +1,24 @@
 # Social Client Search
 
-This example demonstrates a simple Node.js script that searches for potential clients on Facebook and Instagram using Meta's Graph API. You must provide your own access token with the necessary permissions.
+This example demonstrates a small Node.js web app that searches for potential clients on Facebook, Instagram and Twitter.
+It uses Meta's Graph API and Twitter's v2 API. You must supply your own API tokens.
 
-**Usage:**
+## Quick start
+
+Install dependencies with `pnpm install` (requires [pnpm](https://pnpm.io)).
+
+Run the server:
+
+```bash
+FACEBOOK_ACCESS_TOKEN=<fb-token> \
+TWITTER_BEARER_TOKEN=<twitter-token> \
+pnpm start
+```
+
+Open <http://localhost:3000> in your browser and enter a search query.
+
+You can still run the CLI script for Facebook and Instagram only:
 
 ```bash
 FACEBOOK_ACCESS_TOKEN=<token> node client-search.js "search query"
 ```
-
-The script prints basic information about matching Facebook pages and Instagram hashtags.

--- a/social-client-search/README.md
+++ b/social-client-search/README.md
@@ -2,7 +2,7 @@
 
 This example demonstrates a small Node.js web app that searches for potential clients on Facebook, Instagram and Twitter.
 It uses Meta's Graph API and Twitter's v2 API. You must supply your own API tokens.
-Пример ожидает файл `.env` с вашими токенами. Скопируйте `.env.example` и заполните значения.
+Пример ожидает файл `.env` с вашими токенами. Скопируйте `.env.example` и заполните значения. Для Instagram можно указать собственный токен `INSTAGRAM_ACCESS_TOKEN` или использовать тот же, что и для Facebook.
 
 ## Quick start
 
@@ -20,7 +20,9 @@ Open <http://localhost:3000> in your browser and enter a search query.
 You can still run the CLI script for Facebook and Instagram only:
 
 ```bash
-FACEBOOK_ACCESS_TOKEN=<token> node client-search.js "search query"
+FACEBOOK_ACCESS_TOKEN=<token> \
+INSTAGRAM_ACCESS_TOKEN=<token_or_same> \
+node client-search.js "search query"
 ```
 
 Для корректной работы нужны действующие токены от Meta и Twitter.

--- a/social-client-search/README.md
+++ b/social-client-search/README.md
@@ -2,6 +2,7 @@
 
 This example demonstrates a small Node.js web app that searches for potential clients on Facebook, Instagram and Twitter.
 It uses Meta's Graph API and Twitter's v2 API. You must supply your own API tokens.
+Пример ожидает файл `.env` с вашими токенами. Скопируйте `.env.example` и заполните значения.
 
 ## Quick start
 
@@ -10,8 +11,7 @@ Install dependencies with `pnpm install` (requires [pnpm](https://pnpm.io)).
 Run the server:
 
 ```bash
-FACEBOOK_ACCESS_TOKEN=<fb-token> \
-TWITTER_BEARER_TOKEN=<twitter-token> \
+cp .env.example .env # fill in your tokens
 pnpm start
 ```
 
@@ -22,3 +22,5 @@ You can still run the CLI script for Facebook and Instagram only:
 ```bash
 FACEBOOK_ACCESS_TOKEN=<token> node client-search.js "search query"
 ```
+
+Для корректной работы нужны действующие токены от Meta и Twitter.

--- a/social-client-search/client-search.js
+++ b/social-client-search/client-search.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-// Simple script to search Facebook pages and Instagram hashtags using the Graph API
-// Requires a valid access token with appropriate permissions.
+// Простая утилита для поиска клиентов в Facebook и Instagram
+// Требуется действительный токен доступа в переменной окружения FACEBOOK_ACCESS_TOKEN
 
 const token = process.env.FACEBOOK_ACCESS_TOKEN;
 if (!token) {
@@ -14,6 +14,7 @@ if (!query) {
   process.exit(1);
 }
 
+// Поиск публичных страниц Facebook
 async function searchFacebookPages(search) {
   const url = `https://graph.facebook.com/v19.0/search?type=page&q=${encodeURIComponent(search)}&access_token=${token}`;
   const res = await fetch(url);
@@ -24,6 +25,7 @@ async function searchFacebookPages(search) {
   return data.data || [];
 }
 
+// Поиск хэштегов Instagram
 async function searchInstagramHashtags(search) {
   const url = `https://graph.facebook.com/v19.0/ig_hashtag_search?q=${encodeURIComponent(search)}&access_token=${token}`;
   const res = await fetch(url);
@@ -35,6 +37,7 @@ async function searchInstagramHashtags(search) {
 }
 
 (async () => {
+  // Основной поток выполнения
   try {
     const [pages, hashtags] = await Promise.all([
       searchFacebookPages(query),

--- a/social-client-search/client-search.js
+++ b/social-client-search/client-search.js
@@ -1,10 +1,18 @@
 #!/usr/bin/env node
 // Простая утилита для поиска клиентов в Facebook и Instagram
-// Требуется действительный токен доступа в переменной окружения FACEBOOK_ACCESS_TOKEN
+// Требуются действительные токены доступа из переменных окружения
+// FACEBOOK_ACCESS_TOKEN и INSTAGRAM_ACCESS_TOKEN (можно использовать один токен
+// от Meta для обоих сервисов)
 
-const token = process.env.FACEBOOK_ACCESS_TOKEN;
-if (!token) {
+const fbToken = process.env.FACEBOOK_ACCESS_TOKEN;
+const igToken = process.env.INSTAGRAM_ACCESS_TOKEN || fbToken;
+
+if (!fbToken) {
   console.error("FACEBOOK_ACCESS_TOKEN environment variable not set");
+  process.exit(1);
+}
+if (!igToken) {
+  console.error("INSTAGRAM_ACCESS_TOKEN environment variable not set");
   process.exit(1);
 }
 
@@ -16,7 +24,7 @@ if (!query) {
 
 // Поиск публичных страниц Facebook
 async function searchFacebookPages(search) {
-  const url = `https://graph.facebook.com/v19.0/search?type=page&q=${encodeURIComponent(search)}&access_token=${token}`;
+  const url = `https://graph.facebook.com/v19.0/search?type=page&q=${encodeURIComponent(search)}&access_token=${fbToken}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Facebook API error: ${res.status}`);
@@ -27,7 +35,7 @@ async function searchFacebookPages(search) {
 
 // Поиск хэштегов Instagram
 async function searchInstagramHashtags(search) {
-  const url = `https://graph.facebook.com/v19.0/ig_hashtag_search?q=${encodeURIComponent(search)}&access_token=${token}`;
+  const url = `https://graph.facebook.com/v19.0/ig_hashtag_search?q=${encodeURIComponent(search)}&access_token=${igToken}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Instagram API error: ${res.status}`);

--- a/social-client-search/client-search.js
+++ b/social-client-search/client-search.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Simple script to search Facebook pages and Instagram hashtags using the Graph API
+// Requires a valid access token with appropriate permissions.
+
+const token = process.env.FACEBOOK_ACCESS_TOKEN;
+if (!token) {
+  console.error("FACEBOOK_ACCESS_TOKEN environment variable not set");
+  process.exit(1);
+}
+
+const query = process.argv[2];
+if (!query) {
+  console.error('Usage: node client-search.js "search query"');
+  process.exit(1);
+}
+
+async function searchFacebookPages(search) {
+  const url = `https://graph.facebook.com/v19.0/search?type=page&q=${encodeURIComponent(search)}&access_token=${token}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Facebook API error: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.data || [];
+}
+
+async function searchInstagramHashtags(search) {
+  const url = `https://graph.facebook.com/v19.0/ig_hashtag_search?q=${encodeURIComponent(search)}&access_token=${token}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Instagram API error: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.data || [];
+}
+
+(async () => {
+  try {
+    const [pages, hashtags] = await Promise.all([
+      searchFacebookPages(query),
+      searchInstagramHashtags(query),
+    ]);
+
+    console.log("Matching Facebook pages:");
+    for (const page of pages) {
+      console.log(`- ${page.name} (ID: ${page.id})`);
+    }
+
+    console.log("\nMatching Instagram hashtags:");
+    for (const tag of hashtags) {
+      console.log(`- ${tag.name} (ID: ${tag.id})`);
+    }
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/social-client-search/index.html
+++ b/social-client-search/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Social Client Search</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 2rem;
+      }
+      #results {
+        margin-top: 1rem;
+      }
+      .source {
+        margin-top: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Social Client Search</h1>
+    <p>Search for potential clients on Facebook, Instagram, and Twitter.</p>
+    <input id="query" type="text" placeholder="Search query" />
+    <button id="searchBtn">Search</button>
+    <div id="results"></div>
+    <script>
+      document.getElementById('searchBtn').addEventListener('click', async () => {
+        const query = document.getElementById('query').value.trim();
+        if (!query) return;
+        const res = await fetch(`/api/search?query=${encodeURIComponent(query)}`);
+        if (!res.ok) {
+          alert('Error fetching results');
+          return;
+        }
+        const data = await res.json();
+        const resultsDiv = document.getElementById('results');
+        resultsDiv.innerHTML = '';
+        for (const [key, items] of Object.entries(data)) {
+          const section = document.createElement('div');
+          section.className = 'source';
+          const title = document.createElement('h2');
+          title.textContent = key;
+          section.appendChild(title);
+          if (items.length === 0) {
+            section.appendChild(document.createTextNode('No results'));
+          } else {
+            const ul = document.createElement('ul');
+            for (const item of items) {
+              const li = document.createElement('li');
+              li.textContent = item;
+              ul.appendChild(li);
+            }
+            section.appendChild(ul);
+          }
+          resultsDiv.appendChild(section);
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/social-client-search/package.json
+++ b/social-client-search/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "social-client-search",
+  "private": true,
+  "description": "Example app to search for clients on social networks",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/social-client-search/server.js
+++ b/social-client-search/server.js
@@ -1,0 +1,75 @@
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const app = express();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const fbToken = process.env.FACEBOOK_ACCESS_TOKEN;
+const twToken = process.env.TWITTER_BEARER_TOKEN;
+
+if (!fbToken) {
+  console.warn('FACEBOOK_ACCESS_TOKEN not set');
+}
+if (!twToken) {
+  console.warn('TWITTER_BEARER_TOKEN not set');
+}
+
+app.use(express.static(__dirname));
+
+app.get('/api/search', async (req, res) => {
+  const query = req.query.query;
+  if (!query) return res.status(400).json({ error: 'query required' });
+
+  const results = {};
+
+  if (fbToken) {
+    try {
+      const [pages, hashtags] = await Promise.all([
+        fetch(
+          `https://graph.facebook.com/v19.0/search?type=page&q=${encodeURIComponent(
+            query
+          )}&access_token=${fbToken}`
+        ).then((r) => r.json()),
+        fetch(
+          `https://graph.facebook.com/v19.0/ig_hashtag_search?q=${encodeURIComponent(
+            query
+          )}&access_token=${fbToken}`
+        ).then((r) => r.json()),
+      ]);
+      results['Facebook Pages'] = (pages.data || []).map(
+        (p) => `${p.name} (ID: ${p.id})`
+      );
+      results['Instagram Hashtags'] = (hashtags.data || []).map(
+        (t) => `#${t.name} (ID: ${t.id})`
+      );
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  if (twToken) {
+    try {
+      const twRes = await fetch(
+        `https://api.twitter.com/2/users/by?usernames=${encodeURIComponent(
+          query
+        )}`,
+        {
+          headers: { Authorization: `Bearer ${twToken}` },
+        }
+      ).then((r) => r.json());
+      results['Twitter Users'] = (twRes.data || []).map(
+        (u) => `${u.name} (@${u.username})`
+      );
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  res.json(results);
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});

--- a/social-client-search/server.js
+++ b/social-client-search/server.js
@@ -2,9 +2,12 @@ import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+// Небольшой веб-сервер для поиска клиентов
+
 const app = express();
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Токены API берутся из переменных окружения
 const fbToken = process.env.FACEBOOK_ACCESS_TOKEN;
 const twToken = process.env.TWITTER_BEARER_TOKEN;
 
@@ -17,6 +20,7 @@ if (!twToken) {
 
 app.use(express.static(__dirname));
 
+// Маршрут API для выполнения поиска во всех сетях
 app.get('/api/search', async (req, res) => {
   const query = req.query.query;
   if (!query) return res.status(400).json({ error: 'query required' });
@@ -69,6 +73,7 @@ app.get('/api/search', async (req, res) => {
   res.json(results);
 });
 
+// Сервер по умолчанию слушает порт 3000
 const port = process.env.PORT || 3000;
 app.listen(port, () => {
   console.log(`Server running at http://localhost:${port}`);

--- a/social-client-search/server.js
+++ b/social-client-search/server.js
@@ -9,10 +9,14 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Токены API берутся из переменных окружения
 const fbToken = process.env.FACEBOOK_ACCESS_TOKEN;
+const igToken = process.env.INSTAGRAM_ACCESS_TOKEN || fbToken; // Instagram может использовать тот же токен Meta
 const twToken = process.env.TWITTER_BEARER_TOKEN;
 
 if (!fbToken) {
   console.warn('FACEBOOK_ACCESS_TOKEN not set');
+}
+if (!igToken) {
+  console.warn('INSTAGRAM_ACCESS_TOKEN not set');
 }
 if (!twToken) {
   console.warn('TWITTER_BEARER_TOKEN not set');
@@ -38,7 +42,7 @@ app.get('/api/search', async (req, res) => {
         fetch(
           `https://graph.facebook.com/v19.0/ig_hashtag_search?q=${encodeURIComponent(
             query
-          )}&access_token=${fbToken}`
+          )}&access_token=${igToken}`
         ).then((r) => r.json()),
       ]);
       results['Facebook Pages'] = (pages.data || []).map(


### PR DESCRIPTION
## Summary
- add example script for searching Facebook and Instagram via the Meta Graph API

## Testing
- `pnpm test` *(fails: Process with PID 7998 failed to terminate)*
- `pnpm run lint`
- `pnpm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68460c4a47c48331b8ec1bdcb4a0cec5